### PR TITLE
Turn off `react/prefer-stateless-function` rule …

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -75,6 +75,10 @@ module.exports = {
       'react/forbid-prop-types': [
         'off'
       ],
+      'react/prefer-stateless-function': [
+        'error',
+        { 'ignorePureComponents': true }
+      ],
       'import/prefer-default-export': [
         'off'
       ],


### PR DESCRIPTION
They don't play nice with react-test-utils

Use `PureComponent` instead, SS-core is on the version of React which `PureComponent`s were included.