### PR TITLE
MINOR Make global browser variable availables.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -108,6 +108,14 @@ module.exports = {
         'off'
       ],
     }),
+  'overrides': [
+    {
+      "files": ["*-test.js","*-story.js"],
+      "rules": {
+        "import/no-extraneous-dependencies": "off"
+      }
+    }
+  ],
   'settings': {
     'import/extensions': [
       '.js',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,7 +34,8 @@ const todo = {
 module.exports = {
   'extends': 'airbnb',
   'env': {
-    'jasmine': true
+    'jasmine': true,
+    'browser': true
   },
   'rules': Object.assign({},
     todo,


### PR DESCRIPTION
Related https://github.com/silverstripe/silverstripe-cms/issues/1891

This will suppress linting errors when referencing global browser variables like window or document.

Update: I also added a config flag to suppress the _no dev dependencies_ warning when they are importated in `*-story.js` or `*-test.js` files.