### PR TITLE
Prevent eslint rules from cascading.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,6 +37,7 @@ module.exports = {
     'jasmine': true,
     'browser': true
   },
+  'root': true,
   'rules': Object.assign({},
     todo,
     {


### PR DESCRIPTION
This prevents eslint rules from cascading to the parent directory. This prevents the same issue on [ss-userforms](https://github.com/silverstripe/silverstripe-userforms/issues/819).