### PR TITLE
ENH Loosen rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,101 @@ const todo = {
     // can use refs instead
     'off',
   ],
+  'react/default-props-match-prop-types': [
+    'off'
+  ],
+  'react/no-access-state-in-setstate': [
+    'off'
+  ],
+  'default-param-last': [
+    'off'
+  ],
+  'max-classes-per-file': [
+    'off'
+  ],
+  'no-param-reassign': [
+    'off'
+  ],
+  'no-unused-vars': [
+    'off',
+    {
+      'vars': 'local',
+      'ignoreRestSiblings': true
+    }
+  ],
+  'implicit-arrow-linebreak': [
+    'off'
+  ],
+  'no-param-reassign': [
+    'off'
+  ],
+  'no-redeclare': [
+    'off'
+  ],
+  'no-restricted-globals': [
+    'off'
+  ],
+  'no-dupe-keys': [
+    'off'
+  ],
+  // the following can be automatically fixed via the --fix option
+  'import/order': [
+    'off'
+  ],
+  'function-paren-newline': [
+    'off'
+  ],
+  'object-curly-newline': [
+    'off'
+  ],
+  'no-multiple-empty-lines': [
+    'off'
+  ],
+  'prefer-object-spread': [
+    'off'
+  ],
+  'operator-linebreak': [
+    'off'
+  ],
+  'no-else-return': [
+    'off'
+  ],
+  'function-call-argument-newline': [
+    'off'
+  ],
+  'no-unneeded-ternary': [
+    'off'
+  ],
+  'semi-style': [
+    'off'
+  ],
+  'lines-between-class-members': [
+    'off'
+  ],
+  'react/jsx-curly-newline': [
+    'off'
+  ],
+  'react/jsx-wrap-multilines': [
+    'off'
+  ],
+  'react/jsx-tag-spacing': [
+    'off'
+  ],
+  'react/jsx-one-expression-per-line': [
+    'off'
+  ],
+  'react/jsx-fragments': [
+    'off'
+  ],
+  'react/jsx-curly-brace-presence': [
+    'off'
+  ],
+  'react/jsx-closing-tag-location': [
+    'off'
+  ],
+  'react/forbid-foreign-prop-types': [
+    'off'
+  ]
 };
 
 module.exports = {
@@ -41,9 +136,18 @@ module.exports = {
   'rules': Object.assign({},
     todo,
     {
+      "max-len": [
+        "error",
+        {
+          "code": 200,
+        }
+      ],
       // turned off otherwise non-admin modules will complain about importing components from admin
       // via the novel silverstripe js component sharing setup
       'import/no-extraneous-dependencies': [
+        'off'
+      ],
+      'import/no-unresolved': [
         'off'
       ],
       // turned off because the PHP side returns dangling properties which trigger this...
@@ -55,13 +159,6 @@ module.exports = {
             '_t'
           ],
           'allowAfterThis': true
-        }
-      ],
-      'no-unused-vars': [
-        'error',
-        {
-          'vars': 'local',
-          'ignoreRestSiblings': true
         }
       ],
       // increased to error because it's strongly discouraged
@@ -83,7 +180,7 @@ module.exports = {
         'off'
       ],
       'react/prefer-stateless-function': [
-        'error',
+        'off',
         { 'ignorePureComponents': true }
       ],
       'import/prefer-default-export': [
@@ -110,8 +207,66 @@ module.exports = {
       'jsx-a11y/anchor-has-content': [
         'off'
       ],
+      'jsx-a11y/control-has-associated-label': [
+        'off'
+      ],
+      'jsx-a11y/click-events-have-key-events': [
+        'off'
+      ],
+      'jsx-a11y/no-static-element-interactions': [
+        'off'
+      ],
+      'jsx-a11y/anchor-is-valid': [
+        'off'
+      ],
       'no-prototype-builtins': [
         'off'
+      ],
+      'prefer-destructuring': [
+        'off'
+      ],
+      'prefer-promise-reject-errors': [
+        'off'
+      ],
+      'no-promise-executor-return': [
+        'off'
+      ],
+      'func-names': [
+        'off'
+      ],
+      'react/destructuring-assignment': [
+        'off'
+      ],
+      'react/jsx-props-no-spreading': [
+        'off'
+      ],
+      'react/button-has-type': [
+        'off'
+      ],
+      'react/no-array-index-key': [
+        'off'
+      ],
+      'react/jsx-indent': [
+        'off'
+      ],
+      'react/sort-comp': [
+        'off'
+      ],
+      'react/no-unused-prop-types': [
+        'off'
+      ],
+      'react/no-unused-class-component-methods': [
+        'off'
+      ],
+      'react/function-component-definition': [
+        'off'
+      ],
+      // raise warnings because it may cause weird bugs
+      'react/jsx-no-constructed-context-values': [
+        'warn'
+      ],
+      'react/no-unstable-nested-components': [
+        'warn'
       ],
     }),
   'overrides': [


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-admin/issues/1411

Follow up issue https://github.com/silverstripe/silverstripe-admin/issues/1433

There is a huge number of linting issues, over 2,000 on admin alone - https://github.com/silverstripe/silverstripe-admin/actions/runs/3869147541/jobs/6595073564#step:12:4367.  Fixing this will be a massive job.

I think it would be a very poor use of time to refactor all of these just for the sake of airbnb's updated style guide, I'm also I'm not sure I particularly like some of the things in their style guide anyway, such as prefer destructuring which makes harder to read code IMO.

It's too much work to do this pre-beta. I think we should just ignore all the new failures for now (though raise warnings for some things) and maybe aim to implement some of these rules, though realistically this will struggle to get priorities.  Note that AirBNB's style guide is MUCH more comprehensive than PSR2/PSR12

The only other realistic option is too disable linting in CI, though that's pretty awful.  Who knows when we'll turn it back on?

Some examples of rules being loosened for existing code - there are very large numbers of examples for most of these.

[silverstripe/admin/client/src/stories/ValueTracker.js](https://github.com/silverstripe/silverstripe-admin/blob/2/client/src/stories/ValueTracker.js#L48)
  48:41  error  Must use destructuring props assignment                      **react/destructuring-assignment**

[silverstripe/admin/client/src/lib/castStringToElement.js](https://github.com/silverstripe/silverstripe-admin/blob/2/client/src/lib/castStringToElement.js#L50)
  50:23  error  Prop spreading is forbidden  **react/jsx-props-no-spreading**

[silverstripe/admin/client/src/components/TreeDropdownField/TreeDropdownField.js](https://github.com/silverstripe/silverstripe-admin/blob/2/client/src/components/TreeDropdownField/TreeDropdownField.js#L737)
  739:7   error  Use array destructuring                                                                                                                                                                                                                                                                                                                      **prefer-destructuring**

"TODO" section of .eslintrc.js - these are things think we should just ignore for now to get the CMS beta over the line and aim to fix at a later time, there are well over a hundred warnings to fix for all of the following.  I don't see anything here as particularly high value.:

[silverstripe/admin/client/src/containers/InsertLinkModal/tests/InsertLinkModal-test.js](https://github.com/silverstripe/silverstripe-admin/blob/2/client/src/containers/InsertLinkModal/tests/InsertLinkModal-test.js#L13)
  12:1   error  Component should be written as a pure function  **react/prefer-stateless-function**

[silverstripe/admin/client/src/state/toasts/ToastsReducer.js](https://github.com/silverstripe/silverstripe-admin/blob/2/client/src/state/toasts/ToastsReducer.js#L119)
  117:24  error  Default parameters should be last  **default-param-last**


