### PR TITLE
NEW Turn on some ESLint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,9 +22,6 @@ const todo = {
   'arrow-parens': [
     'off'
   ],
-  'indent': [
-    'off'
-  ],
   'react/no-find-dom-node': [
     // can use refs instead
     'off',
@@ -32,20 +29,14 @@ const todo = {
   'react/default-props-match-prop-types': [
     'off'
   ],
-  'react/no-access-state-in-setstate': [
-    'off'
-  ],
   'default-param-last': [
-    'off'
-  ],
-  'max-classes-per-file': [
     'off'
   ],
   'no-param-reassign': [
     'off'
   ],
   'no-unused-vars': [
-    'off',
+    'error',
     {
       'vars': 'local',
       'ignoreRestSiblings': true
@@ -54,32 +45,16 @@ const todo = {
   'implicit-arrow-linebreak': [
     'off'
   ],
-  'no-param-reassign': [
-    'off'
-  ],
   'no-redeclare': [
     'off'
   ],
   'no-restricted-globals': [
     'off'
   ],
-  'no-dupe-keys': [
-    'off'
-  ],
-  // the following can be automatically fixed via the --fix option
-  'import/order': [
-    'off'
-  ],
-  'import/no-cycle': [
-    'off'
-  ],
   'function-paren-newline': [
     'off'
   ],
   'object-curly-newline': [
-    'off'
-  ],
-  'no-multiple-empty-lines': [
     'off'
   ],
   'prefer-object-spread': [
@@ -94,14 +69,12 @@ const todo = {
   'function-call-argument-newline': [
     'off'
   ],
-  'no-unneeded-ternary': [
-    'off'
-  ],
-  'semi-style': [
-    'off'
-  ],
   'lines-between-class-members': [
-    'off'
+    'error',
+    'always',
+    {
+      'exceptAfterSingleLine': true
+    }
   ],
   'react/jsx-curly-newline': [
     'off'
@@ -115,25 +88,10 @@ const todo = {
   'react/jsx-one-expression-per-line': [
     'off'
   ],
-  'react/jsx-fragments': [
-    'off'
-  ],
-  'react/jsx-curly-brace-presence': [
-    'off'
-  ],
   'react/jsx-closing-tag-location': [
     'off'
   ],
-  'react/jsx-no-useless-fragment': [
-    'off'
-  ],
-  'react/no-unused-state': [
-    'off'
-  ],
   'react/forbid-foreign-prop-types': [
-    'off'
-  ],
-  'react/no-deprecated': [
     'off'
   ],
 };
@@ -157,9 +115,6 @@ module.exports = {
       // turned off otherwise non-admin modules will complain about importing components from admin
       // via the novel silverstripe js component sharing setup
       'import/no-extraneous-dependencies': [
-        'off'
-      ],
-      'import/no-unresolved': [
         'off'
       ],
       // turned off because the PHP side returns dangling properties which trigger this...
@@ -192,13 +147,10 @@ module.exports = {
         'off'
       ],
       'react/prefer-stateless-function': [
-        'off',
+        'error',
         { 'ignorePureComponents': true }
       ],
       'import/prefer-default-export': [
-        'off'
-      ],
-      'import/first': [
         'off'
       ],
       'class-methods-use-this': [
@@ -206,11 +158,6 @@ module.exports = {
       ],
       // this one makes no sense in some regex contexts
       'no-useless-escape': [
-        'off'
-      ],
-      // these accessibility rules will be a detriment to existing code/styles,
-      // perhaps in the future
-      'jsx-a11y/href-no-hash': [
         'off'
       ],
       'jsx-a11y/iframe-has-title': [
@@ -255,16 +202,7 @@ module.exports = {
       'react/button-has-type': [
         'off'
       ],
-      'react/no-array-index-key': [
-        'off'
-      ],
-      'react/jsx-indent': [
-        'off'
-      ],
       'react/sort-comp': [
-        'off'
-      ],
-      'react/no-unused-prop-types': [
         'off'
       ],
       'react/no-unused-class-component-methods': [


### PR DESCRIPTION
## Description
Turn on the following ESLint rules:

#### [General rules:](https://eslint.org/docs/latest/rules)
- indent: Enforce consistent indentation. [Link](https://eslint.org/docs/latest/rules/indent)
- no-unused-vars: Disallow unused variables. [Link](https://eslint.org/docs/latest/rules/no-unused-vars#args-none)
- no-dupe-keys: Disallow duplicate keys in object literals. [Link](https://eslint.org/docs/latest/rules/no-dupe-keys)
- no-multiple-empty-lines: Disallow multiple empty lines. [Link](https://eslint.org/docs/latest/rules/no-multiple-empty-lines)
- no-unneeded-ternary: Disallow ternary operators when simpler alternatives exist. [Link](https://eslint.org/docs/latest/rules/no-unneeded-ternary)
- semi-style: Enforce location of semicolons. [Link](https://eslint.org/docs/latest/rules/semi-style)
- lines-between-class-members: Require or disallow an empty line between class members. [Link](https://eslint.org/docs/latest/rules/lines-between-class-members)
- max-classes-per-file: Enforce a maximum number of classes per file. [Link](https://eslint.org/docs/latest/rules/max-classes-per-file)
- no-param-reassign: Disallow reassigning function parameters. [Link](https://eslint.org/docs/latest/rules/no-param-reassign)

#### [JSX-a11y:](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/main/docs/rules)
- jsx-a11y/href-no-hash: Probably was removed from API. Replaced with anchor-is-valid

#### [Import rules:](https://github.com/import-js/eslint-plugin-import/tree/main/docs/rules)
- import/order: Enforce a convention in the order of require() / import statements. [Link](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md)
- import/no-cycle: Ensures that there is no resolvable path back to this module via its dependencies. [Link](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-cycle.md)
- import/no-unresolved: Ensures an imported module can be resolved to a module on the local filesystem, as defined by standard Node require.resolve behavior. [Link](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-unresolved.md)
- import/first: This rule reports any imports that come after non-import statements. [Link](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/first.md)

#### [React lib rules:](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules)
- react/no-access-state-in-setstate[Link](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-access-state-in-setstate.md)
- react/jsx-fragments	Enforce shorthand or standard form for React fragments. [Link](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-fragments.md)
- react/jsx-curly-brace-presence: Disallow unnecessary JSX expressions when literals alone are sufficient or enforce JSX expressions on literals in JSX children or attributes. [Link](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-curly-brace-presence.md)
- react/jsx-no-useless-fragment: Disallow unnecessary fragments. [Link](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-useless-fragment.md)
- react/no-unused-state: Disallow definitions of unused state. [Link](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-state.md)
- react/no-deprecated: Disallow usage of deprecated methods. [Link](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-deprecated.md)
- react/prefer-stateless-function: Enforce stateless components to be written as a pure function. [Link](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prefer-stateless-function.md)
- react/no-array-index-key: Disallow usage of Array index in keys. [Link](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-array-index-key.md) 
- react/jsx-indent: Enforce JSX indentation. [Link](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-indent.md)
- react/no-unused-prop-types: Disallow definitions of unused propTypes. [Link](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md)

#### Should be reviewed and turned on in the future:
- import/prefer-default-export: In exporting files, this rule checks if there is default export or not. [Link](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/prefer-default-export.md)
- jsx-a11y/anchor-is-valid: The HTML a element, with a valid href attribute, is formally defined as representing a hyperlink. [Link](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/anchor-is-valid.md)
- jsx-a11y/iframe-has-title: <iframe> elements must have a unique title property to indicate its content to the user. [Link](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/iframe-has-title.md)
- comma-dangle: Require or disallow trailing commas. [Link](https://eslint.org/docs/latest/rules/comma-dangle)
- arrow-parens: Require parentheses around arrow function arguments. [Link](https://eslint.org/docs/latest/rules/arrow-parens)
- prefer-destructuring: Require destructuring from arrays and/or objects. [Link](https://eslint.org/docs/latest/rules/prefer-destructuring)
- func-names: Require or disallow named function expressions. [Link](https://eslint.org/docs/latest/rules/func-names)
- react/forbid-foreign-prop-types: Disallow using another component's propTypes. [Link](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-foreign-prop-types.md)
- react/prop-types: Disallow missing props validation in a React component definition. [Link](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prop-types.md)
- no-restricted-globals	Disallow specified global variables. [Link](https://eslint.org/docs/latest/rules/no-restricted-globals)
- jsx-a11y/control-has-associated-label: Enforce that a control (an interactive element) has a text label. [Link](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/control-has-associated-label.md)
- jsx-a11y/click-events-have-key-events: Enforce onClick is accompanied by at least one of the following: onKeyUp, onKeyDown, onKeyPress. [Link](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/click-events-have-key-events.md)
- jsx-a11y/no-static-element-interactions: Static HTML elements do not have semantic meaning. [Link](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-static-element-interactions.md)
- react/destructuring-assignment: Enforce consistent usage of destructuring assignment of props, state, and context. [Link](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/destructuring-assignment.md)
- react/button-has-type: Disallow usage of button elements without an explicit type attribute. [Link](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/button-has-type.md)
- react/sort-comp: Enforce component methods order. [Link](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/sort-comp.md)
- default-param-last: Enforce default parameters to be last. [Link](https://eslint.org/docs/latest/rules/default-param-last)
- prefer-object-spread: Disallow using Object.assign with an object literal as the first argument and prefer the use of object spread instead. [Link](https://eslint.org/docs/latest/rules/prefer-object-spread)
- no-redeclare: Disallow variable redeclaration. [Link](https://eslint.org/docs/latest/rules/no-redeclare)
- no-else-return: Disallow else blocks after return statements in if statements. [Link](https://eslint.org/docs/latest/rules/no-else-return)
- function-call-argument-newline: Enforce line breaks between arguments of a function call. [Link](https://eslint.org/docs/latest/rules/function-call-argument-newline)
- react/jsx-wrap-multilines: Disallow missing parentheses around multiline JSX. [Link](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-wrap-multilines.md)
- prefer-promise-reject-errors: Require using Error objects as Promise rejection reasons. [Link](https://eslint.org/docs/latest/rules/prefer-promise-reject-errors)
- no-promise-executor-return: Disallow returning values from Promise executor functions. [Link](https://eslint.org/docs/latest/rules/no-promise-executor-return)
- react/require-default-props: Enforce a defaultProps definition for every prop that is not a required prop. [Link](require-default-props)
- react/default-props-match-prop-types: Enforce all defaultProps have a corresponding non-required PropType. [Link](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/default-props-match-prop-types.md)
- react/no-find-dom-node: Disallow usage of findDOMNode. SUPPRESSED FOR NOW. [Link](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md)

#### Rules that is still remaining turned off:
- react/jsx-closing-tag-location: Enforce closing tag location for multiline JSX. [Link](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-closing-tag-location.md)
- react/jsx-tag-spacing: Enforce whitespace in and around the JSX opening and closing brackets. [Link](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-tag-spacing.md)
- react/jsx-filename-extension: Disallow file extensions that may contain JSX. [Link](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-filename-extension.md)
- function-paren-newline: Enforce consistent line breaks inside function parentheses. [Link](https://eslint.org/docs/latest/rules/function-paren-newline)
- object-curly-newline: Enforce consistent line breaks after opening and before closing braces. [Link](https://eslint.org/docs/latest/rules/object-curly-newline) 
- operator-linebreak: Enforce consistent linebreak style for operators. [Link](https://eslint.org/docs/latest/rules/operator-linebreak)
- react/jsx-curly-newline: Enforce consistent linebreaks in curly braces in JSX attributes and expressions. [Link](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-curly-newline.md)
- react/jsx-one-expression-per-line: Require one JSX element per line. [Link](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-one-expression-per-line.md)
- import/no-extraneous-dependencies: Forbid the import of external modules that are not declared in the package.json's dependencies, devDependencies, optionalDependencies, peerDependencies, or bundledDependencies. The closest parent package.json will be used. [Link](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-extraneous-dependencies.md)
- no-underscore-dangle: Disallow dangling underscores in identifiers. [Link](https://eslint.org/docs/latest/rules/no-underscore-dangle)
- react/forbid-prop-types: Disallow certain propTypes. [Link](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-prop-types.md) 
- class-methods-use-this: Enforce that class methods utilize this. [Link](https://eslint.org/docs/latest/rules/class-methods-use-this)
- no-useless-escape: Disallow unnecessary escape characters. [Link](https://eslint.org/docs/latest/rules/no-useless-escape)
- jsx-a11y/anchor-has-content: Enforce that anchors have content and that the content is accessible to screen readers. Accessible means that it is not hidden using the aria-hidden prop. Refer to the references to learn about why this is important. [Link](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/anchor-has-content.md)
- react/jsx-props-no-spreading: Disallow JSX prop spreading. [Link](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-props-no-spreading.md)
- react/no-unused-class-component-methods: Disallow declaring unused methods of component class. [Link](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-class-component-methods.md)
- react/function-component-definition: Enforce a specific function type for function components. [Link](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/function-component-definition.md)

## Parent issue
- https://github.com/silverstripe/silverstripe-admin/issues/1433

