### PR TITLE
ENH Allow more modern syntax including null-coallescing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -102,6 +102,11 @@ module.exports = {
     'jasmine': true,
     'browser': true
   },
+  // Allows null coalescing and optional chaining operators.
+  // Airbnb uses ecmaVersion 2018
+  'parserOptions': {
+    'ecmaVersion': 2020
+  },
   'root': true,
   'rules': Object.assign({},
     todo,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@silverstripe/eslint-config",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"description": "SilverStripe config files for eslint",
 	"engines": {
 		"node": ">=18.x"


### PR DESCRIPTION
We've needed this change for a while, and I'm using optional chaining (`x?.y`) in https://github.com/silverstripe/silverstripe-asset-admin/pull/1527 which fails linting without this PR.

After merging:
1. create a new `1.4` branch
2. tag `1.4.0` on GitHub
3. Publish `1.4.0` to npm via `yarn publish`

## Issue
- https://github.com/silverstripe/.github/issues/343