### PR TITLE
DEP Limit styelint to 16.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"eslint-plugin-jsx-a11y": "^6.6.1",
 		"eslint-plugin-react": "^7.31.10",
 		"eslint-webpack-plugin": "^3.2.0",
-		"stylelint": "^16.3.1",
+		"stylelint": "~16.12.0",
 		"stylelint-config-recommended": "^14.0.0",
 		"stylelint-config-recommended-scss": "^14.0.0",
 		"stylelint-config-sass-guidelines": "^11.1.0",


### PR DESCRIPTION
Issue https://github.com/silverstripe/documentation-lint/issues/28

qified is a sub-dep so not something we can restrict directly. Limiting stylelint to 16.12.x (latest version is 16.25.0) fixes the issue and allows it to install under node 18. If we were running node 20 or later then we wouldn't need this limit.

Create 1.6 branch and release 1.6.0 after merge, and ensure the new tag shows in npm